### PR TITLE
Update hydra_3d_main.jl

### DIFF
--- a/src/hydra_3d_main.jl
+++ b/src/hydra_3d_main.jl
@@ -16,7 +16,7 @@ using Loess
     Loads a data file created by SaveRun and appends it to the global vectors in the current workspace. 
 """
 function LoadData(Name::String)
-    return load("data\\"*Name*".jld2")["s"]
+    return load(joinpath("data", Name*".jld2"))["s"]
 end
 
 import Main.length


### PR DESCRIPTION
I replaced \\ by the joinpath command which works also under Linux. The symbol \\ as folder separator is specific to Windows, but doesn't work on Linux/Mac